### PR TITLE
Fixes to allow use with S100 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 build
 libcsp*
 .vscode
+.vs
+CMakeSettings.json
 suo
 dump
 *.gch
 .cache
 secret.hpp
+/*_cfg.cpp
+!sample_cfg.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,11 @@ cmake_minimum_required(VERSION 3.16)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(SATELLITE_CONFIG_CPP "sample_cfg.cpp" CACHE STRING "Configuration file to be used")
+
 option(SUPPORT_PORTHOUSE "Compile with porthouse tracking support" OFF)
 option(SUPPORT_RIGCTL "Compile with rigctl tracking support" OFF)
 
-option(USE_EXTERNAL_SECRET "Use HMAC key defined in secret.hpp file" OFF)
 option(OUTPUT_RAW_FRAMES "Open additional ZMQ socket for raw frames" OFF)
 
 
@@ -16,6 +17,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
  
 add_compile_options(-g -Wall -Wextra)
 
+file(GENERATE OUTPUT debug.txt CONTENT "${SATELLITE_CONFIG_CPP}")
 
 # Setup csp_modem executable
 add_executable(csp_modem
@@ -23,7 +25,7 @@ add_executable(csp_modem
     csp_suo_adapter.cpp
     csp_if_zmq_server.cpp
     randomizer.cpp
-)
+    ${SATELLITE_CONFIG_CPP})
 
 
 # Setup Suo library
@@ -54,7 +56,9 @@ endif()
 
 if (USE_EXTERNAL_SECRET)
     target_compile_definitions(csp_modem PRIVATE EXTERNAL_SECRET)
-    #target_compile_definitions(csp_modem PRIVATE HMAC_HACK)
+    if (USE_HMAC_HACK)
+        target_compile_definitions(csp_modem PRIVATE HMAC_HACK)
+    endif()
 endif()
 
 if (OUTPUT_RAW_FRAMES)

--- a/csp_modem.cpp
+++ b/csp_modem.cpp
@@ -62,60 +62,17 @@ int main(int argc, char *argv[])
 
 	try
 	{
-		const float center_frequency = 437.775e6; // [Hz]
+		const float center_frequency = cfg_center_frequency();
 		
-		/*
-		 * SDR
-		 */
-		SoapySDRIO::Config sdr_conf;
-		sdr_conf.rx_on = true;
-		sdr_conf.tx_on = true;
-		sdr_conf.use_time = 1;
-		sdr_conf.samplerate = 500000;
-		sdr_conf.tx_latency = 100; // [samples]
+		// SDR
+		SoapySDRIO sdr(cfg_sdr());
 
-		// sdr_conf.buffer = 1024;
-		sdr_conf.buffer = (sdr_conf.samplerate / 1000); // buffer lenght in milliseconds
-
-		sdr_conf.args["driver"] = "uhd";
-
-		sdr_conf.rx_centerfreq = 436.00e6;
-		sdr_conf.tx_centerfreq = sdr_conf.rx_centerfreq;
-
-		sdr_conf.rx_gain = 30;
-		sdr_conf.tx_gain = 60;
-
-		sdr_conf.rx_antenna = "TX/RX";
-		sdr_conf.tx_antenna = "TX/RX";
-
-		SoapySDRIO sdr(sdr_conf);
-
-
-		/*
-		 * Setup receiver
-		 */
-		GMSKContinousDemodulator::Config demodulator_conf;
-		demodulator_conf.sample_rate = sdr_conf.samplerate;
-		demodulator_conf.center_frequency = center_frequency - sdr_conf.rx_centerfreq;
-		demodulator_conf.symbol_rate = 9600;
-		demodulator_conf.bt = 0.5;
-		demodulator_conf.samples_per_symbol = 4;
-
-		GMSKContinousDemodulator demodulator(demodulator_conf);
+		// Setup receiver
+		GMSKContinousDemodulator demodulator(cfg_gmsk_demodulator());
 		sdr.sinkSamples.connect_member(&demodulator, &GMSKContinousDemodulator::sinkSamples);
 
-		/*
-		 * Setup frame decoder
-		 */
-		GolayDeframer::Config deframer_conf;
-		deframer_conf.syncword = 0x930B51DE;
-		deframer_conf.syncword_len = 32;
-		deframer_conf.sync_threshold = 3;
-		deframer_conf.use_viterbi = false;
-		deframer_conf.use_randomizer = true;
-		deframer_conf.use_rs = true;
-
-		GolayDeframer deframer(deframer_conf);
+		// Setup frame decoder
+		GolayDeframer deframer(cfg_golay_deframer());
 		deframer.syncDetected.connect_member(&demodulator, &GMSKContinousDemodulator::lockReceiver);
 		//deframer.syncDetected.connect([](bool locked, Timestamp now) {
 		//	cout << "locked " << locked << endl;
@@ -123,32 +80,12 @@ int main(int argc, char *argv[])
 		demodulator.sinkSymbol.connect_member(&deframer, &GolayDeframer::sinkSymbol);
 		demodulator.setMetadata.connect_member(&deframer, &GolayDeframer::setMetadata);
 
-		/*
-		 * Setup transmitter
-		 */
-		GMSKModulator::Config modulator_conf;
-		modulator_conf.sample_rate = sdr_conf.samplerate;
-		modulator_conf.center_frequency = center_frequency - sdr_conf.tx_centerfreq;
-		modulator_conf.symbol_rate = 9600;
-		modulator_conf.bt = 0.5;
-		modulator_conf.ramp_up_duration = 2; // [symbols]
-		modulator_conf.ramp_down_duration = 2; // [symbols]
-
-		GMSKModulator modulator(modulator_conf);
+		// Setup transmitter
+		GMSKModulator modulator(cfg_gmsk_modulator());
 		sdr.generateSamples.connect_member(&modulator, &GMSKModulator::generateSamples);
 
-		/*
-		 * Setup framer
-		 */
-		GolayFramer::Config framer_conf;
-		framer_conf.syncword = deframer_conf.syncword;
-		framer_conf.syncword_len = deframer_conf.syncword_len;
-		framer_conf.preamble_len = 24 * 8; // [symbols]
-		framer_conf.use_viterbi = false;
-		framer_conf.use_randomizer = true;
-		framer_conf.use_rs = true;
-
-		GolayFramer framer(framer_conf);
+		// Setup framer
+		GolayFramer framer(cfg_golay_framer());
 		modulator.generateSymbols.connect_member(&framer, &GolayFramer::generateSymbols);
 
 
@@ -161,14 +98,6 @@ int main(int argc, char *argv[])
 		csp_debug_set_level(CSP_PACKET, 1);
 		csp_debug_set_level(CSP_PROTOCOL, 1);
 
-#ifdef OLD_CSP
-		/* Initialize CSP */
-		csp_set_hostname("csp-modem");
-		csp_set_model("CSP Modem");
-		csp_buffer_init(400, 512);
-		csp_init(9);
-		csp_rdp_set_opt(6, 30000, 16000, 1, 8000, 3);
-#else
 		/* Initialize CSP */
 		csp_conf_t csp_conf;
 		csp_conf_get_defaults(&csp_conf);
@@ -177,22 +106,14 @@ int main(int argc, char *argv[])
 		csp_conf.model = "CSPModem";
 		csp_conf.revision = "v1";
 		csp_init(&csp_conf);
-#endif
 
 		/* Start the routing task */
 		csp_route_start_task(1000, 0);
 
-		/* 
-		 * Setup CSP ZMQ interface
-		 */
+		// Setup CSP ZMQ interface
 		csp_iface_t* csp_zmq_if;
-#ifdef OLD_CSP
-		if (csp_zmqserver_init(CSP_NODE_MAC, "0.0.0.0", 0, &csp_zmq_if) != CSP_ERR_NONE)
-			throw SuoError("csp_zmqserver_init");
-#else
 		if (csp_zmqserver_init(CSP_NO_VIA_ADDRESS, "0.0.0.0", 0, &csp_zmq_if) != CSP_ERR_NONE)
 			throw SuoError("csp_zmqserver_init");
-#endif
 
 #ifdef CSP_RTABLE_CIDR 
 		// Route packets going to addresses 8-15 to ZMQ
@@ -205,22 +126,8 @@ int main(int argc, char *argv[])
 				throw SuoError("csp_route_set");
 #endif
 
-		/*
-		 * Setup CSP proxy
-		 */
-		CSPSuoAdapter::Config csp_adapter_conf;
-#ifdef EXTERNAL_SECRET
-#include "secret.hpp"
-		csp_adapter_conf.use_hmac = true;
-		memcpy(csp_adapter_conf.hmac_key, secret_key, sizeof(csp_adapter_conf.hmac_key));
-#else
-		csp_adapter_conf.use_hmac = false;
-#endif
-		csp_adapter_conf.use_rs = false; // Done by GolayFramer/GolayDeframer
-		csp_adapter_conf.use_rand = false; // Done by GolayFramer/GolayDeframer
-		csp_adapter_conf.use_crc = false;
-
-		CSPSuoAdapter csp_adapter(csp_adapter_conf);
+		//Setup CSP proxy
+		CSPSuoAdapter csp_adapter(cfg_csp_suo_adapter());
 		framer.sourceFrame.connect_member(&csp_adapter, &CSPSuoAdapter::sourceFrame);
 		deframer.sinkFrame.connect_member(&csp_adapter, &CSPSuoAdapter::sinkFrame);
 
@@ -235,25 +142,13 @@ int main(int argc, char *argv[])
 				throw SuoError("csp_route_set");
 #endif
 
-
 		/* Start CSP service server */
-#ifdef OLD_CSP
-		csp_thread_create(service_task, (const signed char *const)"Service", 1000, NULL, 0, NULL);
-#else
 		csp_thread_create(service_task, "Service", 1000, NULL, 0, NULL);
-#endif
 
 
 #ifdef USE_PORTHOUSE_TRACKER
-		/*
-		 * Setup porthouse tracker
-		 */
-		PorthouseTracker::Config tracker_conf;
-		tracker_conf.amqp_url = "amqp://guest:guest@localhost/";
-		tracker_conf.target_name = "Suomi-100";
-		tracker_conf.center_frequency = center_frequency; // [Hz]
-
-		PorthouseTracker tracker(tracker_conf);
+		// Setup porthouse tracker
+		PorthouseTracker tracker(cfg_tracker());
 		tracker.setUplinkFrequency.connect([&] (float frequency) {
 			modulator.setFrequencyOffset(frequency - center_frequency);
 		});

--- a/csp_modem.hpp
+++ b/csp_modem.hpp
@@ -1,10 +1,37 @@
 #pragma once
+#include "csp_suo_adapter.hpp"
 
 #include <stdint.h>
 #include <csp/csp.h>
 
+#include <suo.hpp>
+#include <signal-io/soapysdr_io.hpp>
+#include <modem/demod_gmsk_cont.hpp>
+#include <modem/mod_gmsk.hpp>
+#include <framing/golay_framer.hpp>
+#include <framing/golay_deframer.hpp>
+#ifdef USE_PORTHOUSE_TRACKER
+#include <misc/porthouse_tracker.hpp>
+#endif
+
+using namespace std; 
+using namespace suo;
 
 int csp_fec_append(csp_packet_t *packet);
 int csp_fec_decode(csp_packet_t *packet);
 int csp_apply_rand(csp_packet_t *packet);
 
+/*
+ Functions returning config structs and implemented by SATELLITE_CONFIG_CPP
+ */
+float cfg_center_frequency();
+SoapySDRIO::Config cfg_sdr();
+GMSKContinousDemodulator::Config cfg_gmsk_demodulator();
+GolayDeframer::Config cfg_golay_deframer();
+GMSKModulator::Config cfg_gmsk_modulator();
+GolayFramer::Config cfg_golay_framer();
+CSPSuoAdapter::Config cfg_csp_suo_adapter();
+
+#ifdef USE_PORTHOUSE_TRACKER
+PorthouseTracker::Config cfg_tracker();
+#endif

--- a/csp_suo_adapter.hpp
+++ b/csp_suo_adapter.hpp
@@ -16,18 +16,28 @@ public:
 	struct Config {
 		Config();
 
-		bool use_hmac;
-		bool use_rs;
-		bool use_crc;
-		bool use_rand;
-		bool legacy_hmac;
-		uint8_t hmac_key[16];
+		bool rx_use_hmac;
+		bool rx_use_rs;
+		bool rx_use_crc;
+		bool rx_use_rand;
+		bool rx_legacy_hmac;
+		uint8_t rx_hmac_key[16];
 
-		bool use_xtea;
-		uint8_t xtea_key[20];
+		bool rx_use_xtea;
+		uint8_t rx_xtea_key[20];
 
 		/* Filter out frames which originate from ground segment. */
-		bool filter_ground_addresses;
+		bool rx_filter_ground_addresses;
+
+		bool tx_use_hmac;
+		bool tx_use_rs;
+		bool tx_use_crc;
+		bool tx_use_rand;
+		bool tx_legacy_hmac;
+		uint8_t tx_hmac_key[16];
+
+		bool tx_use_xtea;
+		uint8_t tx_xtea_key[20];
 	};
 
 	struct Stats {
@@ -69,3 +79,6 @@ private:
 	bool tx_acked;
 
 };
+
+int custom_csp_hmac_append(uint8_t* hmac_key, csp_packet_t* packet, bool include_header);
+int custom_csp_hmac_verify(uint8_t* hmac_key, csp_packet_t* packet, bool include_header);

--- a/sample_cfg.cpp
+++ b/sample_cfg.cpp
@@ -1,0 +1,146 @@
+#include "csp_modem.hpp"
+
+using namespace std;
+using namespace suo;
+
+
+// given in Hz
+#define CENTER_FREQUENCY 437.5e6
+
+
+float cfg_center_frequency() {
+	cout << "NOTE: Using sample config file!" << endl;
+	cout << "      Please make your own file for your settings and give it to" << endl;
+	cout << "      cmake using -DSATELLITE_CONFIG_CPP=[your config file]" << endl;
+	return CENTER_FREQUENCY;
+}
+
+
+SoapySDRIO::Config cfg_sdr() {
+	SoapySDRIO::Config c;
+	c.rx_on = true;
+	c.tx_on = true;
+	c.use_time = 1;
+	c.samplerate = 8000000;
+	c.tx_latency = 100; // [samples]
+
+	// c.buffer = 1024;
+	c.buffer = (c.samplerate / 1000); // buffer lenght in milliseconds
+
+	c.args["driver"] = "leecher"; // "uhd";
+
+	c.rx_centerfreq = 436.00e6;
+	c.tx_centerfreq = c.rx_centerfreq;
+
+	c.rx_gain = 30;
+	c.tx_gain = 60;
+
+	c.rx_antenna = "TX/RX";
+	c.tx_antenna = "TX/RX";
+
+	return c;
+}
+SoapySDRIO::Config sdr_conf = cfg_sdr();
+
+
+GMSKContinousDemodulator::Config cfg_gmsk_demodulator()
+{
+	GMSKContinousDemodulator::Config c;
+	c.sample_rate = sdr_conf.samplerate;
+	c.center_frequency = CENTER_FREQUENCY - sdr_conf.rx_centerfreq;
+	c.symbol_rate = 9600;
+	c.bt = 0.5;
+	c.samples_per_symbol = 4;
+	c.symsync_bandwidth0 = 0.01;
+	c.symsync_bandwidth1 = 0.01;
+	c.symsync_rate_tol = 0.01;
+	c.verbose = false;
+
+	return c;
+}
+
+
+GolayDeframer::Config cfg_golay_deframer()
+{
+	GolayDeframer::Config c;
+	c.syncword = 0x930B51DE;
+	c.syncword_len = 32;
+	c.sync_threshold = 3;
+	c.use_viterbi = false;
+	c.use_randomizer = true;
+	c.use_rs = true;
+	c.verbose = true;
+
+	return c;
+}
+GolayDeframer::Config deframer_conf = cfg_golay_deframer();
+
+
+GMSKModulator::Config cfg_gmsk_modulator()
+{
+	GMSKModulator::Config c;
+	c.sample_rate = sdr_conf.samplerate;
+	c.center_frequency = CENTER_FREQUENCY - sdr_conf.tx_centerfreq;
+	c.symbol_rate = 9600;
+	c.bt = 0.5;
+	c.ramp_up_duration = 2; // [symbols]
+	c.ramp_down_duration = 2; // [symbols]
+
+	return c;
+}
+
+
+GolayFramer::Config cfg_golay_framer()
+{
+	GolayFramer::Config c;
+	c.syncword = deframer_conf.syncword;
+	c.syncword_len = deframer_conf.syncword_len;
+	c.preamble_len = 24 * 8; // [symbols]
+	c.use_viterbi = false;
+	c.use_randomizer = true;
+	c.use_rs = true;
+	return c;
+}
+
+
+CSPSuoAdapter::Config cfg_csp_suo_adapter()
+{
+	CSPSuoAdapter::Config c;
+	c.rx_use_rs = false;  // Done by GolayDeframer
+	c.rx_use_crc = true;
+	c.rx_use_rand = false;  // Done by GolayDeframer
+	c.rx_use_hmac = false;
+	c.rx_legacy_hmac = false;
+	// c.rx_hmac_key;
+	c.rx_use_xtea = false;
+	// c.rx_xtea_key;
+	c.rx_filter_ground_addresses = true;
+
+	c.tx_use_rs = false;  // Done by GolayFramer
+	c.tx_use_crc = false;
+	c.tx_use_rand = false;  // Done by GolayFramer
+	c.tx_use_hmac = true;
+	c.tx_legacy_hmac = false;
+
+	uint8_t hmac_key[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			              0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+	memcpy(c.tx_hmac_key, hmac_key, sizeof(c.tx_hmac_key));
+	
+	c.tx_use_xtea = false;
+	// c.tx_xtea_key
+
+	return c;
+}
+
+
+#ifdef USE_PORTHOUSE_TRACKER
+PorthouseTracker::Config cfg_tracker()
+{
+	PorthouseTracker::Config c;
+	c.amqp_url = "amqp://guest:guest@localhost/";
+	c.target_name = "SampleSat-1000";
+	c.center_frequency = CENTER_FREQUENCY; // [Hz]
+
+	return c;
+}
+#endif


### PR DESCRIPTION
Refactored code so that user-specific configuration is given using a custom cpp file that is given as a cmake argument. Support different CSP configurations for RX and TX, removing the need for HMAC_HACK. Removed code related to OLD_CSP. Fixed metadata accessing for stats. Always free CSP buffer if returning early when receiving frames.