### PR TITLE
Filter ground-originating frames based on packet.id.src (actual port) instead of .sport

### DIFF
--- a/csp_suo_adapter.cpp
+++ b/csp_suo_adapter.cpp
@@ -333,7 +333,7 @@ void CSPSuoAdapter::sinkFrame(const Frame &frame, Timestamp now)
 	packet->id.ext = csp_ntoh32(packet->id.ext);
 
 	/* Ignore frame if source port indicates that is coming from ground segment. */
-	if (conf.rx_filter_ground_addresses && packet->id.sport > 8) {
+	if (conf.rx_filter_ground_addresses && packet->id.src > 8) {
 		csp_log_info("Frame filtered");
 		csp_buffer_free(packet);
 		return;


### PR DESCRIPTION
E.g. commands like "eps conf get" did not work as the packets originating on the satellite EPS have packet.id.sport == 18, while the actual node id was in packet.id.src == 2.



